### PR TITLE
Support for --variable

### DIFF
--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -829,7 +829,7 @@ if($PrintLibs) {
 if($PrintLibsOnlyl or ($PrintLibsOnlyl and $PrintLibsOnlyL)) {
     print grep /^-l/, $o->get_ldflags;
 } elsif ($PrintLibsOnlyL) {
-	print grep /^-L/, $o->get_ldflags;
+	print grep /^-[LR]/, $o->get_ldflags;
 }
 
 print "\n";


### PR DESCRIPTION
Hi,

I added support for pkg-config --variable option, where desired variable from pc file will be printed out. The behaviour is the same as for pkg-config.

Btw, thanks for this great tool. I'm planing to use it  on systems where stock pkg-config is not available by default, like *BSD's or Minix.

Regards,
Sanel
