### PR TITLE
use $^X to make sure that test against the same perl that you are instal...

### DIFF
--- a/t/PkgConfigTest.pm
+++ b/t/PkgConfigTest.pm
@@ -40,7 +40,7 @@ our $S;
 my $SCRIPT = __DIR__ . "/../script/pkg-config.pl";
 sub run_common {
     my @args = @_;
-    (my $ret = qx($SCRIPT --env-only @args))
+    (my $ret = qx($^X $SCRIPT --env-only @args))
         =~ s/(?:^\s+)|($?:\s+$)//g;
     $RV = $?;
     $S = $ret;


### PR DESCRIPTION
This fixes the bug I reported on rt here:

https://rt.cpan.org/Public/Bug/Display.html?id=92088

I didn't realize that this distro was hosted on github, so I am providing a pull request here in the hopes that It might make it easy to fix.

Also, I'd be happy to help out in applying some of the patches here and on RT and cutting a new release if you don't have the time to do it yourself.
