### PR TITLE
github repository meta information

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,16 @@ WriteMakefile(
         'Archive::Extract' => 0,
         'Fcntl' => 0
     },
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/mnunberg/perl-PkgConfig.git',
+                web  => 'https://github.com/mnunberg/perl-PkgConfig',
+            },
+        },
+    },
     
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'PkgConfig-*' },


### PR DESCRIPTION
This will add a "Clone Repository" link in metacpan that will point directly to the github repository so that developers can find it easily.
