### PR TITLE
rename pkg-config => ppkg-config and install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /blib/
 /pm_to_blib
 /MANIFEST.bak
+/PkgConfig-*

--- a/MANIFEST
+++ b/MANIFEST
@@ -8,6 +8,7 @@ MANIFEST.SKIP
 PkgConfig.kpf
 README
 script/pkg-config.pl
+script/ppkg-config
 t/00-load.t
 t/01-script_detailed.t
 t/02-iterfiles-FLISTaa.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,7 @@ WriteMakefile(
       ? ('LICENSE'=> 'perl')
       : ()),
     PL_FILES            => {},
+    EXE_FILES           => [ 'script/ppkg-config', $^O ne 'MSWin32' ? 'script/pkg-config.pl' : () ],
     PREREQ_PM => {
         'Test::More' => 0,
     },

--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -743,7 +743,7 @@ if($PrintAPIversion) {
 
 if($PrintRealVersion) {
 
-    printf STDOUT ("pkg-config.pl - cruftless pkg-config\n" .
+    printf STDOUT ("ppkg-config - cruftless pkg-config\n" .
             "Version: %s\n", $PkgConfig::VERSION);
     exit(0);
 }
@@ -823,8 +823,8 @@ if($PrintLibs) {
 }
 
 # handle --libs-only-L and --libs-only-l but watch the case when
-# we got 'pkg-config.pl --libs-only-L --libs-only-l foo' which must behave just like
-# 'pkg-config.pl --libs-only-l foo'
+# we got 'ppkg-config --libs-only-L --libs-only-l foo' which must behave just like
+# 'ppkg-config --libs-only-l foo'
 
 if($PrintLibsOnlyl or ($PrintLibsOnlyl and $PrintLibsOnlyL)) {
     print grep /^-l/, $o->get_ldflags;
@@ -853,13 +853,15 @@ will be sanitized in a future 'release/stable' version.
 
 =head2 As a replacement for C<pkg-config>
 
-    $ pkg-config.pl --libs --cflags --static gio-2.0
+    $ ppkg-config --libs --cflags --static gio-2.0
 
     #outputs (lines artifically broken up for readability):
     # -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include
     # -pthread -lgio-2.0 -lz -lresolv -lgobject-2.0
     # -lgmodule-2.0 -ldl -lgthread-2.0 -pthread -lrt -lglib-2.0
 
+C<pkg-config.pl> can be used as an alias for C<ppkg-config> on platforms that
+support it.
 
 Compare to:
     $ pkg-config --libs --cflags --static gio-2.0

--- a/script/ppkg-config
+++ b/script/ppkg-config
@@ -1,0 +1,1 @@
+../lib/PkgConfig.pm

--- a/t/PkgConfigTest.pm
+++ b/t/PkgConfigTest.pm
@@ -38,7 +38,7 @@ $ENV{PKG_CONFIG_PATH} = join(":", @PC_PATHS);
 our $RV;
 our $S;
 
-my $SCRIPT = $FindBin::Bin . "/../script/pkg-config.pl";
+my $SCRIPT = $FindBin::Bin . "/../script/ppkg-config";
 sub run_common {
     my @args = @_;
     (my $ret = qx($^X $SCRIPT --env-only @args))


### PR DESCRIPTION
This is my alternate proposal to fix rt#84174.  There is some precedent for pure-perl versions of system tools with a 'p' prefix and my personal preference is not to use the .pl extension for scripts that are installed.

My main usage will be via PkgConfig rather than the command line though so it is a mild preference.
