### PR TITLE
fix "debian9 pkg-config.pl --modversion geany" problem

### DIFF
--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1166,7 +1166,7 @@ if($WantFlags) {
 }
 
 my %pc_options;
-if($PrintExists || $AtLeastVersion || $ExactVersion || $MaxVersion) {
+if($PrintExists || $AtLeastVersion || $ExactVersion || $MaxVersion || $PrintVersion) {
     $pc_options{no_recurse} = 1;
 }
 


### PR DESCRIPTION
on debian9 "pkg-config.pl --modversion geany" command return empty string ("")

when run "pkg-config.pl --modversion --silence-errors geany"
output is:
Can\'t find gtk+-2.0.pc in any of /usr/local/lib/x86_64-linux-gnu/pkgconfig /usr/local/lib/pkgconfig /usr/local/share/pkgconfig /usr/lib/x86_64-linux-gnu/pkgconfig /usr/lib/pkgconfig /usr/share/pkgconfig
use the PKG_CONFIG_PATH environment variable, or
specify extra search paths via \'search_paths\

how to reproduse:
install debian9 (without any gtk develop packages)
install cpanm
run "apt-get install geany" (geany will be on the first line of "pkg-config.pl --list-all" output)
run (for example) "cpanm FFI::Platypus"

cpanm fail on Alien-Base-ModuleBuild on t/version.t line 30
because a command "pkg-config.pl --modversion geany" return empty string ("")

we do not need "no_recurse" param = 0 (PkgConfig.pm line 1170) when run pkg-config.pl with --modversion flag.