### PR TITLE
Add Missing Prerequisite, Env.pm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -69,6 +69,7 @@ WriteMakefile(
     EXE_FILES           => \@scripts,
     PREREQ_PM => {
         'Test::More' => '0.94',
+        'Env' => '1.04',
     },
     BUILD_REQUIRES => {
         'ExtUtils::MakeMaker' => '6.56',


### PR DESCRIPTION
As noted by @Util, you are missing Env as a prerequisite in your Makefile.PL.
It appears that Env is used by PkgConfig in 2 places:
https://github.com/PerlPkgConfig/perl-PkgConfig/blob/667c5e9eec7549e8d2d755464838341b44f0c6ed/t/lib/PkgConfig/Path.pm#L6
https://github.com/PerlPkgConfig/perl-PkgConfig/blob/3cb41c3dbb738b083d4d767bb6e6f31dd83ac217/t/env.t#L4
Hopefully this 1-line pull request should fix this issue!