### PR TITLE
adjustments to work under PAR::Packer executables derived from Strawberry perl

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ install:
   - cp lib\PkgConfig.pm script\pkg-config.pl
   - cp lib\PkgConfig.pm script\ppkg-config
   - perl gen_multi_tests.pl
+  - cpanm --notest --quiet pp
 
 build: off
 

--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -270,12 +270,21 @@ if($ENV{PKG_CONFIG_NO_OS_CUSTOMIZATION}) {
     require Config;
     if($Config::Config{myuname} =~ /strawberry-perl/)
     {
-        my($vol, $dir, $file) = File::Spec->splitpath($^X);
-        my @dirs = File::Spec->splitdir($dir);
-        splice @dirs, -3;
-        my $path = (File::Spec->catdir($vol, @dirs, qw( c lib pkgconfig )));
-        $path =~ s{\\}{/}g;
-        @DEFAULT_SEARCH_PATH = $path;
+        #  handle PAR::Packer executables which have $^X eq "perl.exe"
+        if ($ENV{PAR_0})
+        {
+            my $path = $ENV{PAR_TEMP};
+            $path =~ s{\\}{/}g;
+            @DEFAULT_SEARCH_PATH = ($path);
+        }
+        else {
+            my($vol, $dir, $file) = File::Spec->splitpath($^X);
+            my @dirs = File::Spec->splitdir($dir);
+            splice @dirs, -3;
+            my $path = (File::Spec->catdir($vol, @dirs, qw( c lib pkgconfig )));
+            $path =~ s{\\}{/}g;
+            @DEFAULT_SEARCH_PATH = $path;
+        }
     }
     
     my @reg_paths;
@@ -327,9 +336,9 @@ if($ENV{PKG_CONFIG_NO_OS_CUSTOMIZATION}) {
         );
     }
     
-    # See caveats above for Strawberry
+    # See caveats above for Strawberry and PAR::Packer
     require Config;
-    if($Config::Config{myuname} =~ /strawberry-perl/)
+    if(not $ENV{PAR_0} and $Config::Config{myuname} =~ /strawberry-perl/)
     {
         my($vol, $dir, $file) = File::Spec->splitpath($^X);
         my @dirs = File::Spec->splitdir($dir);

--- a/t/par_packer.t
+++ b/t/par_packer.t
@@ -12,25 +12,26 @@ plan skip_all => "Test only for strawberry MSWin32" unless $Config{myuname} =~ /
 plan skip_all => "Test needs pp utility to be installed" unless 'require pp';
 plan tests => 3;
 
-my $dir = tempdir( CLEANUP => 1);
-my $exe_file = "$dir/a.exe";
-my $test_text = "executable worked";
-
-#  avoid shell quoting issues
-$exe_file =~ s|\\|/|g;
-
-use pp;
-
-$ENV{PP_OPTS} = qq{-e "use PkgConfig; print qq|$test_text|" -o $exe_file};
-
-#diag $ENV{PP_OPTS};
-
-ok (pp->go(), 'ran the pp call');
-
-ok (-x $exe_file, "generated executable file $exe_file");
-
-my $result = `$exe_file`;
-
-is ($result, $test_text, "PAR packed executable includes functional PkgConfig");
-
-#diag $result;
+if (require pp) {
+    my $dir = tempdir( CLEANUP => 1);
+    my $exe_file = "$dir/a.exe";
+    my $test_text = "executable worked";
+    
+    #  avoid shell quoting issues
+    $exe_file =~ s|\\|/|g;
+    
+    
+    $ENV{PP_OPTS} = qq{-e "use PkgConfig; print qq|$test_text|" -o $exe_file};
+    
+    #diag $ENV{PP_OPTS};
+    
+    ok (pp->go(), 'ran the pp call');
+    
+    ok (-x $exe_file, "generated executable file $exe_file");
+    
+    my $result = `$exe_file`;
+    
+    is ($result, $test_text, "PAR packed executable includes functional PkgConfig");
+    
+    #diag $result;
+}

--- a/t/par_packer.t
+++ b/t/par_packer.t
@@ -6,13 +6,15 @@ use PkgConfig;
 use Config;
 use File::Temp qw( tempdir );
 
+my $have_pp = eval 'require pp';
 
 plan skip_all => "Test only for MSWin32" unless $^O eq 'MSWin32';
 plan skip_all => "Test only for strawberry MSWin32" unless $Config{myuname} =~ /strawberry-perl/;
-plan skip_all => "Test needs pp utility to be installed" unless 'require pp';
+plan skip_all => "Test needs pp utility to be installed" unless $have_pp;
+
 plan tests => 3;
 
-if (require pp) {
+if ($have_pp) {
     my $dir = tempdir( CLEANUP => 1);
     my $exe_file = "$dir/a.exe";
     my $test_text = "executable worked";

--- a/t/par_packer.t
+++ b/t/par_packer.t
@@ -9,20 +9,28 @@ use File::Temp qw( tempdir );
 
 plan skip_all => "Test only for MSWin32" unless $^O eq 'MSWin32';
 plan skip_all => "Test only for strawberry MSWin32" unless $Config{myuname} =~ /strawberry-perl/;
-plan skip_all => "Test needs PAR::Packer to be installed" unless 'require PAR::Packer';
-plan tests => 1;
+plan skip_all => "Test needs pp utility to be installed" unless 'require pp';
+plan tests => 3;
 
 my $dir = tempdir( CLEANUP => 1);
 my $exe_file = "$dir/a.exe";
 my $test_text = "executable worked";
 
-my $code = qq{pp -e "use PkgConfig; print qq|$test_text|" -o $exe_file};
+#  avoid shell quoting issues
+$exe_file =~ s|\\|/|g;
 
-#diag $code;
+use pp;
 
-system $code;
+$ENV{PP_OPTS} = qq{-e "use PkgConfig; print qq|$test_text|" -o $exe_file};
+
+#diag $ENV{PP_OPTS};
+
+ok (pp->go(), 'ran the pp call');
+
+ok (-x $exe_file, "generated executable file $exe_file");
+
 my $result = `$exe_file`;
 
-is $result, $test_text, "PAR packed executable includes functional PkgConfig";
+is ($result, $test_text, "PAR packed executable includes functional PkgConfig");
 
 #diag $result;

--- a/t/par_packer.t
+++ b/t/par_packer.t
@@ -6,34 +6,28 @@ use PkgConfig;
 use Config;
 use File::Temp qw( tempdir );
 
-my $have_pp = eval 'require pp';
 
 plan skip_all => "Test only for MSWin32" unless $^O eq 'MSWin32';
 plan skip_all => "Test only for strawberry MSWin32" unless $Config{myuname} =~ /strawberry-perl/;
-plan skip_all => "Test needs pp utility to be installed" unless $have_pp;
+plan skip_all => "Test needs pp utility to be installed" unless eval { require pp };
 
 plan tests => 3;
 
-if ($have_pp) {
-    my $dir = tempdir( CLEANUP => 1);
-    my $exe_file = "$dir/a.exe";
-    my $test_text = "executable worked";
-    
-    #  avoid shell quoting issues
-    $exe_file =~ s|\\|/|g;
-    
-    
-    $ENV{PP_OPTS} = qq{-e "use PkgConfig; print qq|$test_text|" -o $exe_file};
-    
-    #diag $ENV{PP_OPTS};
-    
-    ok (pp->go(), 'ran the pp call');
-    
-    ok (-x $exe_file, "generated executable file $exe_file");
-    
-    my $result = `$exe_file`;
-    
-    is ($result, $test_text, "PAR packed executable includes functional PkgConfig");
-    
-    #diag $result;
-}
+my $dir = tempdir( CLEANUP => 1);
+my $exe_file = "$dir/a.exe";
+my $test_text = "executable worked";
+
+#  avoid shell quoting issues
+$exe_file =~ s|\\|/|g;
+
+
+$ENV{PP_OPTS} = qq{-e "use PkgConfig; print qq|$test_text|" -o $exe_file};
+
+ok (pp->go(), 'ran the pp call');
+
+ok (-x $exe_file, "generated executable file $exe_file");
+
+my $result = `$exe_file`;
+
+is ($result, $test_text, "PAR packed executable includes functional PkgConfig");
+

--- a/t/par_packer.t
+++ b/t/par_packer.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+BEGIN { delete $ENV{PKG_CONFIG_PATH} }
+use PkgConfig;
+use Config;
+use File::Temp qw( tempdir );
+
+
+plan skip_all => "Test only for MSWin32" unless $^O eq 'MSWin32';
+plan skip_all => "Test only for strawberry MSWin32" unless $Config{myuname} =~ /strawberry-perl/;
+plan skip_all => "Test needs PAR::Packer to be installed" unless 'require PAR::Packer';
+plan tests => 1;
+
+my $dir = tempdir( CLEANUP => 1);
+my $exe_file = "$dir/a.exe";
+my $test_text = "executable worked";
+
+my $code = qq{pp -e "use PkgConfig; print qq|$test_text|" -o $exe_file};
+
+#diag $code;
+
+system $code;
+my $result = `$exe_file`;
+
+is $result, $test_text, "PAR packed executable includes functional PkgConfig";
+
+#diag $result;


### PR DESCRIPTION
Here's a PR for #43 

The test is currently skipped if PAR::Packer is not installed, but should perhaps be entirely optional.

The code also only handles the Strawberry perl derived case - no other operating systems are checked.  

The second check for the exclude flags is skipped entirely.  Perhaps it should clear them instead to avoid pollution of PAR expectations from the calling system, but that's a more general issue.
