### PR TITLE
Avoid 'used only once' warnings 

### DIFF
--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -516,6 +516,7 @@ sub _pc_var {
     $vname =~ s,\.,DOT,g;
     no strict 'refs';
     $vname = $self->_get_pc_varname($vname);
+    no warnings qw(once);
     my $glob = *{$vname};
     $glob ? $$glob : ();
 }


### PR DESCRIPTION
Avoid 'used only once' warnings when the pc file is incomplete and this module is used in a BEGIN block.

See also issue #45.