### PR TITLE
quote-protect executable- and file-names in case of spaces

### DIFF
--- a/t/PkgConfigTest.pm
+++ b/t/PkgConfigTest.pm
@@ -49,7 +49,7 @@ $SCRIPT = $FindBin::Bin . "/../lib/PkgConfig.pm"
 
 sub run_common {
     my @args = @_;
-    (my $ret = qx($^X $SCRIPT --env-only @args))
+    (my $ret = qx("$^X" "$SCRIPT" --env-only @args))
         =~ s/(?:^\s+)|($?:\s+$)//g;
     $RV = $?;
     $S = $ret;


### PR DESCRIPTION
Without this, the tests blow up on my "perl in space" setup.