### PR TITLE
Print errors

### DIFF
--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1086,7 +1086,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 
-my $print_errors = 1;
+my $print_errors = 0;
 my @ARGV_PRESERVE = @ARGV;
 
 my @POD_USAGE_SECTIONS = (

--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1180,11 +1180,11 @@ if($PrintRealVersion) {
 }
 
 if($PrintErrors) {
-    $print_errors = 0;
+    $print_errors = 1;
 }
 
 if($SilenceErrors) {
-    $print_errors = 1;
+    $print_errors = 0;
 }
 
 # This option takes precedence over all other options
@@ -1199,7 +1199,7 @@ if ($ErrToStdOut) {
 my $WantFlags = ($PrintCflags || $PrintLibs || $PrintLibsOnlyL || $PrintCflagsOnlyI || $PrintCflagsOnlyOther || $PrintLibsOnlyOther || $PrintLibsOnlyl || $PrintVersion);
 
 if($WantFlags) {
-    $print_errors = 0 unless $SilenceErrors;
+    $print_errors = 1 unless $SilenceErrors;
 }
 
 my %pc_options;

--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1086,7 +1086,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 
-my $quiet_errors = 1;
+my $print_errors = 1;
 my @ARGV_PRESERVE = @ARGV;
 
 my @POD_USAGE_SECTIONS = (
@@ -1180,11 +1180,11 @@ if($PrintRealVersion) {
 }
 
 if($PrintErrors) {
-    $quiet_errors = 0;
+    $print_errors = 0;
 }
 
 if($SilenceErrors) {
-    $quiet_errors = 1;
+    $print_errors = 1;
 }
 
 # This option takes precedence over all other options
@@ -1193,13 +1193,13 @@ if($SilenceErrors) {
 # or
 # --print-errors
 if ($ErrToStdOut) {
- $quiet_errors = 2;
+ $print_errors = 2;
 }
 
 my $WantFlags = ($PrintCflags || $PrintLibs || $PrintLibsOnlyL || $PrintCflagsOnlyI || $PrintCflagsOnlyOther || $PrintLibsOnlyOther || $PrintLibsOnlyl || $PrintVersion);
 
 if($WantFlags) {
-    $quiet_errors = 0 unless $SilenceErrors;
+    $print_errors = 0 unless $SilenceErrors;
 }
 
 my %pc_options;
@@ -1248,10 +1248,10 @@ my $o = PkgConfig->find(\@FINDLIBS, %pc_options);
 
 if($o->errmsg) {
     # --errors-to-stdout
-    if ($quiet_errors eq 2) {
+    if ($print_errors eq 2) {
         print STDOUT $o->errmsg;
     # --print-errors
-    } elsif ($quiet_errors eq 1) {
+    } elsif ($print_errors eq 1) {
         print STDERR $o->errmsg;
     }
     # --silence-errors

--- a/lib/PkgConfig.pm
+++ b/lib/PkgConfig.pm
@@ -1248,10 +1248,10 @@ my $o = PkgConfig->find(\@FINDLIBS, %pc_options);
 
 if($o->errmsg) {
     # --errors-to-stdout
-    if ($print_errors eq 2) {
+    if ($print_errors == 2) {
         print STDOUT $o->errmsg;
     # --print-errors
-    } elsif ($print_errors eq 1) {
+    } elsif ($print_errors == 1) {
         print STDERR $o->errmsg;
     }
     # --silence-errors

--- a/t/print_errors.t
+++ b/t/print_errors.t
@@ -17,9 +17,31 @@ my $nonexistent_lib = 'libtrilophosuchus-rackhami';
 
 my $re_error_message = qr/^Can't find $nonexistent_lib.pc in any of /m;
 
-subtest 'ppkg-config with non-existent lib' => sub {
+my %test_data = (
+  'no-arg' => {
+    stdout => 'unlike',
+    stderr => 'unlike',
+  },
+  '--print-errors' => {
+    stdout => 'unlike',
+    stderr => 'like',
+  },
+  '--silence-errors' => {
+    stdout => 'unlike',
+    stderr => 'unlike',
+  },
+  '--errors-to-stdout' => {
+    stdout => 'like',
+    stderr => 'unlike',
+  },
+  
+);
 
-  my @command = ( @pkg_config, $nonexistent_lib );
+
+foreach my $test_name (sort keys %test_data) {
+  my @command
+    = grep {$_ ne 'no-arg'}
+      ( @pkg_config, $test_name, $nonexistent_lib );
 
   note "% @command";
   my($out, $err, $ret) = capture {
@@ -28,75 +50,22 @@ subtest 'ppkg-config with non-existent lib' => sub {
   };
 
   is $ret, 256, "error code correct";
-  is $out, "", "nothing to stdout";
-  is $err, "", "nothing to stderr";
-  note "out: $out" if defined $out;
-  note "err: $err" if defined $err;
-
-  done_testing();
-};
-
-
-subtest 'ppkg-config --print-errors with non-existent lib' => sub {
-
-  my @command = ( @pkg_config, '--print-errors', $nonexistent_lib );
-
-  note "% @command";
-  my($out, $err, $ret) = capture {
-    system @command;
-    $?;
-  };
-
-  is $ret, 256, "error code correct";
-  is $out, "", "nothing to stdout";
-  like $err,
-    $re_error_message,
-    "errors went to stderr";
+  if ($test_data{$test_name}{stdout} eq 'like') {
+    like $out, $re_error_message, "stdout for $test_name contains error string";
+  }
+  else {
+    unlike $out, $re_error_message, "stdout for $test_name does not contain error string";
+  }
+  if ($test_data{$test_name}{stderr} eq 'like') {
+    like $err, $re_error_message, "stderr for $test_name contains error string";
+  }
+  else {
+    unlike $err, $re_error_message, "stderr for $test_name does not contain error string";
+  }
   note "out: $out" if defined $out;
   note "err: $err" if defined $err;
   
-  done_testing();
-};
-
-subtest 'ppkg-config --silence-errors with non-existent lib' => sub {
-
-  my @command = ( @pkg_config, '--silence-errors', $nonexistent_lib );
-
-  note "% @command";
-  my($out, $err, $ret) = capture {
-    system @command;
-    $?;
-  };
-
-  is $ret, 256, "error code correct";
-  is $out, "", "no errors to stdout";
-  is $err, "", "no errors to stderr";
-  note "out: $out" if defined $out;
-  note "err: $err" if defined $err;
-
-  done_testing();
-};
-
-subtest 'ppkg-config --errors-to-stdout with non-existent lib' => sub {
-
-  my @command = ( @pkg_config, '--errors-to-stdout', $nonexistent_lib );
-
-  note "% @command";
-  my($out, $err, $ret) = capture {
-    system @command;
-    $?;
-  };
-
-  is $ret, 256, "error code correct";
-  like $out,
-    $re_error_message,
-    "errors went to stdout";
-  is $err, "", "nothing to stderr";
-  note "out: $out" if defined $out;
-  note "err: $err" if defined $err;
-
-  done_testing();
-};
+}
 
 
 done_testing();

--- a/t/print_errors.t
+++ b/t/print_errors.t
@@ -15,6 +15,8 @@ my @pkg_config = ( $^X, $INC{'PkgConfig.pm'} );
 #  crocodile from the Miocene Riversleigh fauna.  
 my $nonexistent_lib = 'libtrilophosuchus-rackhami';
 
+my $re_error_message = qr/^Can't find $nonexistent_lib.pc in any of /;
+
 subtest 'ppkg-config with non-existent lib' => sub {
 
   my @command = ( @pkg_config, $nonexistent_lib );
@@ -48,7 +50,7 @@ subtest 'ppkg-config --print-errors with non-existent lib' => sub {
   is $ret, 256, "error code correct";
   is $out, "", "nothing to stdout";
   like $err,
-    qr/^Can't find $nonexistent_lib.pc in any of /,
+    $re_error_message,
     "errors went to stderr";
   note "out: $out" if defined $out;
   note "err: $err" if defined $err;
@@ -87,7 +89,7 @@ subtest 'ppkg-config --errors-to-stdout with non-existent lib' => sub {
 
   is $ret, 256, "error code correct";
   like $out,
-    qr/^Can't find $nonexistent_lib.pc in any of /,
+    $re_error_message,
     "errors went to stdout";
   is $err, "", "nothing to stderr";
   note "out: $out" if defined $out;
@@ -97,4 +99,4 @@ subtest 'ppkg-config --errors-to-stdout with non-existent lib' => sub {
 };
 
 
-done_testing;
+done_testing();

--- a/t/print_errors.t
+++ b/t/print_errors.t
@@ -1,0 +1,76 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use PkgConfig::Capture;
+use Test::More;
+use PkgConfig;
+
+note "DEFAULT_SEARCH_PATH = $_" for @PkgConfig::DEFAULT_SEARCH_PATH;
+
+# adjust to test with real pkg-config
+my @pkg_config = ( $^X, $INC{'PkgConfig.pm'} );
+#my @pkg_config = ( 'pkg-config' );
+
+
+my $nonexistent_lib = 'rubbish-no-exists';
+
+subtest 'ppkg-config --print-errors with non-existent lib' => sub {
+
+  my @command = ( @pkg_config, '--print-errors', $nonexistent_lib );
+
+  note "% @command";
+  my($out, $err, $ret) = capture {
+    system @command;
+    $?;
+  };
+
+  is $ret, 256;
+  is $out, "";
+  like $err,
+    qr/^Can't find $nonexistent_lib.pc in any of /,
+    "errors went to stderr";
+  note "out: $out" if defined $out;
+  note "err: $err" if defined $err;
+
+};
+
+subtest 'ppkg-config --silence-errors with non-existent lib' => sub {
+
+  my @command = ( @pkg_config, '--silence-errors', $nonexistent_lib );
+
+  note "% @command";
+  my($out, $err, $ret) = capture {
+    system @command;
+    $?;
+  };
+
+  is $ret, 256;
+  is $out, "", "no errors to stdout";
+  is $err, "", "no errors to stderr";
+  note "out: $out" if defined $out;
+  note "err: $err" if defined $err;
+
+};
+
+subtest 'ppkg-config --errors-to-stdout with non-existent lib' => sub {
+
+  my @command = ( @pkg_config, '--errors-to-stdout', $nonexistent_lib );
+
+  note "% @command";
+  my($out, $err, $ret) = capture {
+    system @command;
+    $?;
+  };
+
+  is $ret, 256;
+  like $out,
+    qr/^Can't find $nonexistent_lib.pc in any of /,
+    "errors went to stdout";
+  is $err, "";
+  note "out: $out" if defined $out;
+  note "err: $err" if defined $err;
+
+};
+
+
+done_testing;

--- a/t/print_errors.t
+++ b/t/print_errors.t
@@ -15,7 +15,7 @@ my @pkg_config = ( $^X, $INC{'PkgConfig.pm'} );
 #  crocodile from the Miocene Riversleigh fauna.  
 my $nonexistent_lib = 'libtrilophosuchus-rackhami';
 
-my $re_error_message = qr/^Can't find $nonexistent_lib.pc in any of /;
+my $re_error_message = qr/^Can't find $nonexistent_lib.pc in any of /m;
 
 subtest 'ppkg-config with non-existent lib' => sub {
 

--- a/t/print_errors.t
+++ b/t/print_errors.t
@@ -11,8 +11,29 @@ note "DEFAULT_SEARCH_PATH = $_" for @PkgConfig::DEFAULT_SEARCH_PATH;
 my @pkg_config = ( $^X, $INC{'PkgConfig.pm'} );
 #my @pkg_config = ( 'pkg-config' );
 
+#  assuming nobody will create a library named after an extinct
+#  crocodile from the Miocene Riversleigh fauna.  
+my $nonexistent_lib = 'libtrilophosuchus-rackhami';
 
-my $nonexistent_lib = 'rubbish-no-exists';
+subtest 'ppkg-config with non-existent lib' => sub {
+
+  my @command = ( @pkg_config, $nonexistent_lib );
+
+  note "% @command";
+  my($out, $err, $ret) = capture {
+    system @command;
+    $?;
+  };
+
+  is $ret, 256, "error code correct";
+  is $out, "", "nothing to stdout";
+  is $err, "", "nothing to stderr";
+  note "out: $out" if defined $out;
+  note "err: $err" if defined $err;
+
+  done_testing();
+};
+
 
 subtest 'ppkg-config --print-errors with non-existent lib' => sub {
 
@@ -24,14 +45,15 @@ subtest 'ppkg-config --print-errors with non-existent lib' => sub {
     $?;
   };
 
-  is $ret, 256;
-  is $out, "";
+  is $ret, 256, "error code correct";
+  is $out, "", "nothing to stdout";
   like $err,
     qr/^Can't find $nonexistent_lib.pc in any of /,
     "errors went to stderr";
   note "out: $out" if defined $out;
   note "err: $err" if defined $err;
-
+  
+  done_testing();
 };
 
 subtest 'ppkg-config --silence-errors with non-existent lib' => sub {
@@ -44,12 +66,13 @@ subtest 'ppkg-config --silence-errors with non-existent lib' => sub {
     $?;
   };
 
-  is $ret, 256;
+  is $ret, 256, "error code correct";
   is $out, "", "no errors to stdout";
   is $err, "", "no errors to stderr";
   note "out: $out" if defined $out;
   note "err: $err" if defined $err;
 
+  done_testing();
 };
 
 subtest 'ppkg-config --errors-to-stdout with non-existent lib' => sub {
@@ -62,14 +85,15 @@ subtest 'ppkg-config --errors-to-stdout with non-existent lib' => sub {
     $?;
   };
 
-  is $ret, 256;
+  is $ret, 256, "error code correct";
   like $out,
     qr/^Can't find $nonexistent_lib.pc in any of /,
     "errors went to stdout";
-  is $err, "";
+  is $err, "", "nothing to stderr";
   note "out: $out" if defined $out;
   note "err: $err" if defined $err;
 
+  done_testing();
 };
 
 


### PR DESCRIPTION
This should address the points in #53 

~~Note that the command line calls are untested at the moment.  Any approach would probably benefit from Capture::Tiny, but I did not want to unilaterally add an extra dependency.~~

~~Such a test should also only run when there is a blib/script dir in place as the versions in the top level script dir seem not to be updated.~~

Edit: Found and adapted tests from t/gh36.t



 